### PR TITLE
Allow invalid_reference_casting

### DIFF
--- a/tokenizers/src/models/bpe/trainer.rs
+++ b/tokenizers/src/models/bpe/trainer.rs
@@ -414,6 +414,7 @@ impl BpeTrainer {
         word_counts: &HashMap<String, u32>,
         model: &mut BPE,
     ) -> Result<Vec<AddedToken>> {
+	#![allow(invalid_reference_casting)]
         let mut word_to_id: HashMap<String, u32> = HashMap::with_capacity(self.vocab_size);
         let mut id_to_word: Vec<String> = Vec::with_capacity(self.vocab_size);
 


### PR DESCRIPTION
Rust 1.73.0 sets invalid_reference_casting as the default. It does not allow unsafe cast.
https://github.com/rust-lang/rust/issues/116410
Tokenizers uses the feature, so this PR disables invalid_reference_casting.